### PR TITLE
respect incoming host headers when generating object/bucket urls

### DIFF
--- a/storage/gcsemu/filestore.go
+++ b/storage/gcsemu/filestore.go
@@ -39,7 +39,7 @@ func (fs *filestore) CreateBucket(bucket string) error {
 	return os.MkdirAll(bucketDir, 0777)
 }
 
-func (fs *filestore) GetBucketMeta(bucket string) (*storage.Bucket, error) {
+func (fs *filestore) GetBucketMeta(baseUrl httpBaseUrl, bucket string) (*storage.Bucket, error) {
 	f := fs.filename(bucket, "")
 	fInfo, err := os.Stat(f)
 	if err != nil {
@@ -49,13 +49,13 @@ func (fs *filestore) GetBucketMeta(bucket string) (*storage.Bucket, error) {
 		return nil, fmt.Errorf("stating %s: %w", f, err)
 	}
 
-	obj := bucketMeta(bucket)
+	obj := bucketMeta(baseUrl, bucket)
 	obj.Updated = fInfo.ModTime().UTC().Format(time.RFC3339Nano)
 	return obj, nil
 }
 
-func (fs *filestore) Get(bucket string, filename string) (*storage.Object, []byte, error) {
-	obj, err := fs.GetMeta(bucket, filename)
+func (fs *filestore) Get(baseUrl httpBaseUrl, bucket string, filename string) (*storage.Object, []byte, error) {
+	obj, err := fs.GetMeta(baseUrl, bucket, filename)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,7 +71,7 @@ func (fs *filestore) Get(bucket string, filename string) (*storage.Object, []byt
 	return obj, contents, nil
 }
 
-func (fs *filestore) GetMeta(bucket string, filename string) (*storage.Object, error) {
+func (fs *filestore) GetMeta(baseUrl httpBaseUrl, bucket string, filename string) (*storage.Object, error) {
 	f := fs.filename(bucket, filename)
 	fInfo, err := os.Stat(f)
 	if err != nil {
@@ -81,7 +81,7 @@ func (fs *filestore) GetMeta(bucket string, filename string) (*storage.Object, e
 		return nil, fmt.Errorf("stating  %s: %w", f, err)
 	}
 
-	return fs.ReadMeta(bucket, filename, fInfo)
+	return fs.ReadMeta(baseUrl, bucket, filename, fInfo)
 }
 
 func (fs *filestore) Add(bucket string, filename string, contents []byte, meta *storage.Object) error {
@@ -98,8 +98,7 @@ func (fs *filestore) Add(bucket string, filename string, contents []byte, meta *
 	now := time.Now().UTC()
 	_ = os.Chtimes(f, now, now)
 
-	initMeta(meta, bucket, filename, uint64(len(contents)))
-	scrubMeta(meta)
+	initScrubbedMeta(meta, filename)
 	meta.Metageneration = 1
 	if meta.TimeCreated == "" {
 		meta.TimeCreated = now.UTC().Format(time.RFC3339Nano)
@@ -114,8 +113,7 @@ func (fs *filestore) Add(bucket string, filename string, contents []byte, meta *
 }
 
 func (fs *filestore) UpdateMeta(bucket string, filename string, meta *storage.Object, metagen int64) error {
-	initMeta(meta, bucket, filename, 0)
-	scrubMeta(meta)
+	initScrubbedMeta(meta, filename)
 	meta.Metageneration = metagen
 
 	fMeta := metaFilename(fs.filename(bucket, filename))
@@ -126,31 +124,30 @@ func (fs *filestore) UpdateMeta(bucket string, filename string, meta *storage.Ob
 	return nil
 }
 
-func (fs *filestore) Copy(srcBucket string, srcFile string, dstBucket string, dstFile string) (*storage.Object, error) {
+func (fs *filestore) Copy(srcBucket string, srcFile string, dstBucket string, dstFile string) (bool, error) {
 	// Make sure it's there
-	meta, err := fs.GetMeta(srcBucket, srcFile)
+	meta, err := fs.GetMeta(dontNeedUrls, srcBucket, srcFile)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	// Handle object-not-found
 	if meta == nil {
-		return nil, nil
+		return false, nil
 	}
 
 	// Copy with metadata
 	f1 := fs.filename(srcBucket, srcFile)
 	contents, err := ioutil.ReadFile(f1)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	meta.TimeCreated = "" // reset creation time on the dest file
 	err = fs.Add(dstBucket, dstFile, contents, meta)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 
-	// Reread the updated metadata and return it.
-	return fs.GetMeta(dstBucket, dstFile)
+	return true, nil
 }
 
 func (fs *filestore) Delete(bucket string, filename string) error {
@@ -195,7 +192,7 @@ func (fs *filestore) Delete(bucket string, filename string) error {
 	return nil
 }
 
-func (fs *filestore) ReadMeta(bucket string, filename string, fInfo os.FileInfo) (*storage.Object, error) {
+func (fs *filestore) ReadMeta(baseUrl httpBaseUrl, bucket string, filename string, fInfo os.FileInfo) (*storage.Object, error) {
 	if fInfo.IsDir() {
 		return nil, nil
 	}
@@ -216,7 +213,7 @@ func (fs *filestore) ReadMeta(bucket string, filename string, fInfo os.FileInfo)
 		}
 	}
 
-	initMeta(obj, bucket, filename, uint64(fInfo.Size()))
+	initMetaWithUrls(baseUrl, obj, bucket, filename, uint64(fInfo.Size()))
 	obj.Generation = fInfo.ModTime().UnixNano() // use the mod time as the generation number
 	obj.Updated = fInfo.ModTime().UTC().Format(time.RFC3339Nano)
 	return obj, nil

--- a/storage/gcsemu/meta.go
+++ b/storage/gcsemu/meta.go
@@ -58,25 +58,26 @@ func scrubMeta(meta *storage.Object) {
 
 // Return the URL for a bucket.
 func bucketUrl(baseUrl httpBaseUrl, bucket string) string {
-	if baseUrl == dontNeedUrls || baseUrl == "https://storage.googleapis.com/" {
-		baseUrl = "https://www.googleapis.com/"
-	} else if baseUrl == "http://storage.googleapis.com/" {
-		baseUrl = "http://www.googleapis.com/"
-	}
-	return fmt.Sprintf("%sstorage/v1/b/%s", baseUrl, bucket)
+	return fmt.Sprintf("%sstorage/v1/b/%s", normalizeBaseUrl(baseUrl), bucket)
 }
 
 // Return the URL for a file.
 func objectUrl(baseUrl httpBaseUrl, bucket string, filepath string) string {
-	if baseUrl == dontNeedUrls || baseUrl == "https://storage.googleapis.com/" {
-		baseUrl = "https://www.googleapis.com/"
-	} else if baseUrl == "http://storage.googleapis.com/" {
-		baseUrl = "http://www.googleapis.com/"
-	}
-	return fmt.Sprintf("%sstorage/v1/b/%s/o/%s", baseUrl, bucket, filepath)
+	return fmt.Sprintf("%sstorage/v1/b/%s/o/%s", normalizeBaseUrl(baseUrl), bucket, filepath)
 }
 
-// emulator base baseUrl, including trailing slash; e.g. https://www.googleapis.com/
+// emulator base URL, including trailing slash; e.g. https://www.googleapis.com/
 type httpBaseUrl string
 
+// when the caller doesn't really care about the object meta URLs
 const dontNeedUrls = httpBaseUrl("")
+
+func normalizeBaseUrl(baseUrl httpBaseUrl) httpBaseUrl {
+	if baseUrl == dontNeedUrls || baseUrl == "https://storage.googleapis.com/" {
+		return "https://www.googleapis.com/"
+	} else if baseUrl == "http://storage.googleapis.com/" {
+		return "http://www.googleapis.com/"
+	} else {
+		return baseUrl
+	}
+}

--- a/storage/gcsemu/meta.go
+++ b/storage/gcsemu/meta.go
@@ -8,17 +8,29 @@ import (
 	"google.golang.org/api/storage/v1"
 )
 
-func bucketMeta(bucket string) *storage.Bucket {
+func bucketMeta(baseUrl httpBaseUrl, bucket string) *storage.Bucket {
 	return &storage.Bucket{
 		Kind:         "storage#bucket",
 		Name:         bucket,
-		SelfLink:     bucketUrl(bucket),
+		SelfLink:     bucketUrl(baseUrl, bucket),
 		StorageClass: "STANDARD",
 	}
 }
 
-// initMeta "bakes" metadata with intrinsic values.
-func initMeta(meta *storage.Object, bucket string, filename string, size uint64) {
+// initScrubbedMeta "bakes" metadata with intrinsic values and removes fields that are intrinsic / computed.
+func initScrubbedMeta(meta *storage.Object, filename string) {
+	parts := strings.Split(filename, ".")
+	ext := parts[len(parts)-1]
+
+	if meta.ContentType == "" {
+		meta.ContentType = mime.TypeByExtension(ext)
+	}
+	meta.Name = filename
+	scrubMeta(meta)
+}
+
+// initMetaWithUrls "bakes" metadata with intrinsic values, including computed links.
+func initMetaWithUrls(baseUrl httpBaseUrl, meta *storage.Object, bucket string, filename string, size uint64) {
 	parts := strings.Split(filename, ".")
 	ext := parts[len(parts)-1]
 
@@ -27,9 +39,9 @@ func initMeta(meta *storage.Object, bucket string, filename string, size uint64)
 		meta.ContentType = mime.TypeByExtension(ext)
 	}
 	meta.Kind = "storage#object"
-	meta.MediaLink = objectUrl(bucket, filename) + "?alt=media"
+	meta.MediaLink = objectUrl(baseUrl, bucket, filename) + "?alt=media"
 	meta.Name = filename
-	meta.SelfLink = objectUrl(bucket, filename)
+	meta.SelfLink = objectUrl(baseUrl, bucket, filename)
 	meta.Size = size
 	meta.StorageClass = "STANDARD"
 }
@@ -44,13 +56,23 @@ func scrubMeta(meta *storage.Object) {
 	meta.StorageClass = ""
 }
 
-// Return the URL for a file.  Note that this will generally not be useful as an input an http request due to the way
-// that net/url does character substitution (see comments above).
-func bucketUrl(bucket string) string {
-	return fmt.Sprintf("https://www.googleapis.com/storage/v1/b/%s", bucket)
+// Return the URL for a bucket.
+func bucketUrl(baseUrl httpBaseUrl, bucket string) string {
+	if baseUrl == "" {
+		baseUrl = "https://www.googleapis.com/"
+	}
+	return fmt.Sprintf("%sstorage/v1/b/%s", baseUrl, bucket)
 }
 
 // Return the URL for a file.
-func objectUrl(bucket string, filepath string) string {
-	return fmt.Sprintf("https://www.googleapis.com/storage/v1/b/%s/o/%s", bucket, filepath)
+func objectUrl(baseUrl httpBaseUrl, bucket string, filepath string) string {
+	if baseUrl == "" {
+		baseUrl = "https://www.googleapis.com/"
+	}
+	return fmt.Sprintf("%sstorage/v1/b/%s/o/%s", baseUrl, bucket, filepath)
 }
+
+// emulator base baseUrl, including trailing slash; e.g. https://www.googleapis.com/
+type httpBaseUrl string
+
+const dontNeedUrls = httpBaseUrl("")

--- a/storage/gcsemu/meta.go
+++ b/storage/gcsemu/meta.go
@@ -58,16 +58,20 @@ func scrubMeta(meta *storage.Object) {
 
 // Return the URL for a bucket.
 func bucketUrl(baseUrl httpBaseUrl, bucket string) string {
-	if baseUrl == "" {
+	if baseUrl == dontNeedUrls || baseUrl == "https://storage.googleapis.com/" {
 		baseUrl = "https://www.googleapis.com/"
+	} else if baseUrl == "http://storage.googleapis.com/" {
+		baseUrl = "http://www.googleapis.com/"
 	}
 	return fmt.Sprintf("%sstorage/v1/b/%s", baseUrl, bucket)
 }
 
 // Return the URL for a file.
 func objectUrl(baseUrl httpBaseUrl, bucket string, filepath string) string {
-	if baseUrl == "" {
+	if baseUrl == dontNeedUrls || baseUrl == "https://storage.googleapis.com/" {
 		baseUrl = "https://www.googleapis.com/"
+	} else if baseUrl == "http://storage.googleapis.com/" {
+		baseUrl = "http://www.googleapis.com/"
 	}
 	return fmt.Sprintf("%sstorage/v1/b/%s/o/%s", baseUrl, bucket, filepath)
 }

--- a/storage/gcsemu/store.go
+++ b/storage/gcsemu/store.go
@@ -13,13 +13,13 @@ type Store interface {
 	CreateBucket(bucket string) error
 
 	// Get returns a bucket's metadata.
-	GetBucketMeta(bucket string) (*storage.Bucket, error)
+	GetBucketMeta(baseUrl httpBaseUrl, bucket string) (*storage.Bucket, error)
 
 	// Get returns a file's contents and metadata.
-	Get(bucket string, filename string) (*storage.Object, []byte, error)
+	Get(url httpBaseUrl, bucket string, filename string) (*storage.Object, []byte, error)
 
 	// GetMeta returns a file's metadata.
-	GetMeta(bucket string, filename string) (*storage.Object, error)
+	GetMeta(url httpBaseUrl, bucket string, filename string) (*storage.Object, error)
 
 	// Add creates the specified file.
 	Add(bucket string, filename string, contents []byte, meta *storage.Object) error
@@ -28,13 +28,13 @@ type Store interface {
 	UpdateMeta(bucket string, filename string, meta *storage.Object, metagen int64) error
 
 	// Copy copies the file
-	Copy(srcBucket string, srcFile string, dstBucket string, dstFile string) (*storage.Object, error)
+	Copy(srcBucket string, srcFile string, dstBucket string, dstFile string) (bool, error)
 
 	// Delete deletes the file.
 	Delete(bucket string, filename string) error
 
 	// ReadMeta reads the GCS metadata for a file, when you already have file info.
-	ReadMeta(bucket string, filename string, fInfo os.FileInfo) (*storage.Object, error)
+	ReadMeta(url httpBaseUrl, bucket string, filename string, fInfo os.FileInfo) (*storage.Object, error)
 
 	// Walks the given bucket.
 	Walk(ctx context.Context, bucket string, cb func(ctx context.Context, filename string, fInfo os.FileInfo) error) error

--- a/storage/gcsemu/util.go
+++ b/storage/gcsemu/util.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"google.golang.org/api/googleapi"
 )
@@ -58,4 +60,69 @@ func mustJson(val interface{}) []byte {
 		panic(err)
 	}
 	return b
+}
+
+// RequestHost returns the host from an http.Request, respecting proxy headers. Works locally with devproxy
+// and gulp proxies as well as in AppEngine (both real GAE and the dev_appserver).
+func requestHost(req *http.Request) string {
+	// proxies like gulp are supposed to accumulate original host, next-step-host, etc in order from
+	// client-most to server-most in X-ForwardedHost; return the first entry from that if any are listed
+	if proxyHost := req.Header.Get("X-Forwarded-Host"); proxyHost != "" {
+		// Use the first (closest to client) host
+		splits := strings.SplitN(proxyHost, ",", 2)
+		return splits[0]
+	}
+
+	// Forwarded is the standardized version of X-Forwarded-Host.
+	f := parseForwardedHeader(req.Header.Get("Forwarded"))
+	if len(f.Host) > 0 && len(f.Host[0]) > 0 {
+		return f.Host[0]
+	}
+
+	// Clients that generate HTTP/2 requests should use the :authority header instead
+	// of Host. See http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.3
+	host := req.Header.Get("Authority")
+	if len(host) > 0 {
+		return host
+	}
+
+	// Fall back to the host line.
+	return req.Host
+}
+
+// forwarded represents the values of a Forwarded HTTP header.
+//
+// For more details, see the RFC: https://tools.ietf.org/html/rfc7239 and
+// MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded.
+type forwarded struct {
+	By    []string
+	For   []string
+	Host  []string
+	Proto []string
+}
+
+var (
+	forwardedHostRx = regexp.MustCompile(`(?i)host=(.*?)(?:[,;\s]|$)`)
+)
+
+func removeDoubleQuotes(s string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
+}
+
+// TODO(nishanth): This currently only supports the forwarded.Host field.
+func parseForwardedHeader(s string) forwarded {
+	var f forwarded
+
+	if s == "" {
+		return f
+	}
+
+	matches := forwardedHostRx.FindAllStringSubmatch(s, -1)
+	for _, m := range matches {
+		if len(m) > 0 {
+			f.Host = append(f.Host, removeDoubleQuotes(m[1]))
+		}
+	}
+
+	return f
 }

--- a/storage/gcsemu/util.go
+++ b/storage/gcsemu/util.go
@@ -62,7 +62,7 @@ func mustJson(val interface{}) []byte {
 	return b
 }
 
-// RequestHost returns the host from an http.Request, respecting proxy headers. Works locally with devproxy
+// requestHost returns the host from an http.Request, respecting proxy headers. Works locally with devproxy
 // and gulp proxies as well as in AppEngine (both real GAE and the dev_appserver).
 func requestHost(req *http.Request) string {
 	// proxies like gulp are supposed to accumulate original host, next-step-host, etc in order from
@@ -109,7 +109,7 @@ func removeDoubleQuotes(s string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
 }
 
-// TODO(nishanth): This currently only supports the forwarded.Host field.
+// Note: this currently only supports the forwarded.Host field.
 func parseForwardedHeader(s string) forwarded {
 	var f forwarded
 

--- a/storage/gcsemu/walk.go
+++ b/storage/gcsemu/walk.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Iterate over the file system to serve a GCS list-bucket request.
-func (g *GcsEmu) makeBucketListResults(ctx context.Context, w http.ResponseWriter, delimiter string, cursor string, prefix string, bucket string, maxResults int) {
+func (g *GcsEmu) makeBucketListResults(ctx context.Context, baseUrl httpBaseUrl, w http.ResponseWriter, delimiter string, cursor string, prefix string, bucket string, maxResults int) {
 	var errAbort = errors.New("sentinel error to abort walk")
 	const walkVerbose = true
 
@@ -115,7 +115,7 @@ func (g *GcsEmu) makeBucketListResults(ctx context.Context, w http.ResponseWrite
 	// Resolve the found items.
 	var items []*storage.Object
 	for _, item := range found {
-		if obj, err := g.store.ReadMeta(bucket, item.filename, item.fInfo); err != nil {
+		if obj, err := g.store.ReadMeta(baseUrl, bucket, item.filename, item.fInfo); err != nil {
 			// return our partial results + the cursor so that the client can retry from this point
 			g.log(nil, "failed to resolve: %s", item.filename)
 			break


### PR DESCRIPTION
https://github.com/fullstorydev/emulators/issues/4

Instead of hard-coding the base url for generated object and bucket urls, use the incoming 