### PR TITLE
Storage: enforce compose limit

### DIFF
--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -183,6 +183,13 @@ func (g *GcsEmu) handleGcsCompose(ctx context.Context, baseUrl HttpBaseUrl, w ht
 		g.gapiError(w, http.StatusBadRequest, "bad compose request")
 		return
 	}
+	if len(req.SourceObjects) == 0 {
+		g.gapiError(w, http.StatusBadRequest, "no source objects provided")
+		return
+	} else if len(req.SourceObjects) > 32 {
+		g.gapiError(w, http.StatusBadRequest, "too many source objects provided")
+		return
+	}
 	dst := composeObj{
 		filename: parts[0],
 		conds:    conds,

--- a/storage/gcsemu/gcsemu_test.go
+++ b/storage/gcsemu/gcsemu_test.go
@@ -615,6 +615,16 @@ func testCompose(t *testing.T, bh BucketHandle) {
 	assert.NilError(t, r.Close(), "failed to close composed file reader")
 	assert.Equal(t, manualCompose+source1, string(data), "content doesn't match")
 
+	// enforce compose source limits
+	sourceCount := 33
+	tooManySources := make([]*storage.ObjectHandle, sourceCount)
+	for i := 0; i < sourceCount; i++ {
+		tooManySources[i] = bh.Object(fmt.Sprintf("src-%d", i))
+	}
+	composer = dest.ComposerFrom(tooManySources...)
+	_, err = composer.Run(ctx)
+	assert.Equal(t, http.StatusBadRequest, httpStatusCodeOf(err), "wrong error code returned")
+
 	// Make sure we get a 404 if the source doesn't exist
 	dneObj := bh.Object("dneObject")
 	_ = dneObj.Delete(ctx)


### PR DESCRIPTION
There is a limit of 32 files that can be composed with one compose operation in GCS. Update the emulator to enforce this limit as well as failing when zero sources are provided.