### PR TITLE
Fix gcsemulator install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ Our storage emulator was written in house.
 ### Installing
 
 ```sh
-go get github.com/fullstorydev/emulators/storage
-go install github.com/fullstorydev/emulators/storage/... # for the command-line `gcsemulator`
+go install github.com/fullstorydev/emulators/storage/cmd/gcsemulator@latest
 ```
 
 ### Running, out of process


### PR DESCRIPTION
I tried following the instructions, and the error messages guided me to this, which worked.