### PR TITLE
bigtable: use bigtable.Timestamp internally

### DIFF
--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -1039,7 +1039,7 @@ func applyMutations(tbl *table, r *btpb.Row, muts []*btpb.Mutation, now bigtable
 			}
 			ts := set.TimestampMicros
 			if ts == -1 { // bigtable.ServerTime
-				ts = int64(now)
+				ts = int64(now.TruncateToMilliseconds())
 			}
 			if !tbl.validTimestamp(ts) {
 				return fmt.Errorf("invalid timestamp %d", ts)
@@ -1193,7 +1193,7 @@ func (s *server) ReadModifyWriteRow(ctx context.Context, req *btpb.ReadModifyWri
 
 		fam := getOrCreateFamily(r, rule.FamilyName)
 		col := getOrCreateColumn(fam, rule.ColumnQualifier)
-		ts := int64(now)
+		ts := int64(now.TruncateToMilliseconds())
 		var newCell *btpb.Cell
 		var prevVal []byte
 		if len(col.Cells) > 0 {

--- a/bigtable/bttest/leveldb_test.go
+++ b/bigtable/bttest/leveldb_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
+
+	"cloud.google.com/go/bigtable"
 )
 
 var (
@@ -42,8 +43,8 @@ func TestLevelDbMem(t *testing.T) {
 		svr := &server{
 			tables:  make(map[string]*table),
 			storage: LeveldbMemStorage{},
-			clock: func() time.Time {
-				return time.Unix(0, 0).UTC()
+			clock: func() bigtable.Timestamp {
+				return 0
 			},
 		}
 
@@ -69,8 +70,8 @@ func TestLevelDbDisk(t *testing.T) {
 		svr := &server{
 			tables:  make(map[string]*table),
 			storage: LeveldbDiskStorage{Root: "./test-out"},
-			clock: func() time.Time {
-				return time.Unix(0, 0).UTC()
+			clock: func() bigtable.Timestamp {
+				return 0
 			},
 		}
 

--- a/bigtable/bttest/setup_test.go
+++ b/bigtable/bttest/setup_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
+	"cloud.google.com/go/bigtable"
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	btapb "google.golang.org/genproto/googleapis/bigtable/admin/v2"
 	btpb "google.golang.org/genproto/googleapis/bigtable/v2"
@@ -35,8 +35,8 @@ func newClient(t *testing.T) (context.Context, *clientIntf, bool) {
 	svr := &server{
 		tables:  make(map[string]*table),
 		storage: BtreeStorage{},
-		clock: func() time.Time {
-			return time.Unix(0, 0).UTC()
+		clock: func() bigtable.Timestamp {
+			return 0
 		},
 	}
 


### PR DESCRIPTION
Avoid using `time.Time`, just use `bigtable.Timestamp` consistently.