### PR TITLE
storage: auto decompress gzipped request body

### DIFF
--- a/storage/Makefile
+++ b/storage/Makefile
@@ -24,7 +24,7 @@ vet:
 
 .PHONY: staticcheck
 staticcheck:
-	@go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+	@go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 	staticcheck ./...
 
 .PHONY: ineffassign

--- a/storage/gcsemu/filestore_test.go
+++ b/storage/gcsemu/filestore_test.go
@@ -28,10 +28,10 @@ func TestFileStore(t *testing.T) {
 		},
 	})
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", gcsEmu.Handler)
+	gcsEmu.Register(mux)
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("about to method=%s host=%s u=%s", r.Method, r.Host, r.URL)
-		gcsEmu.Handler(w, r)
+		mux.ServeHTTP(w, r)
 	}))
 	t.Cleanup(svr.Close)
 

--- a/storage/gcsemu/http_wrappers.go
+++ b/storage/gcsemu/http_wrappers.go
@@ -1,0 +1,35 @@
+package gcsemu
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+)
+
+// DrainRequestHandler wraps the given handler to drain the incoming request body on exit.
+func DrainRequestHandler(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			// Always drain and close the request body to properly free up the connection.
+			// See https://groups.google.com/forum/#!topic/golang-nuts/pP3zyUlbT00
+			_, _ = io.Copy(io.Discard, r.Body)
+			_ = r.Body.Close()
+		}()
+		h(w, r)
+	}
+}
+
+// GzipRequestHandler wraps the given handler to automatically decompress gzipped content.
+func GzipRequestHandler(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			gzr, err := gzip.NewReader(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			r.Body = gzr
+		}
+		h(w, r)
+	}
+}

--- a/storage/gcsemu/memstore_test.go
+++ b/storage/gcsemu/memstore_test.go
@@ -22,10 +22,10 @@ func TestMemStore(t *testing.T) {
 		},
 	})
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", gcsEmu.Handler)
+	gcsEmu.Register(mux)
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("about to method=%s host=%s u=%s", r.Method, r.Host, r.URL)
-		gcsEmu.Handler(w, r)
+		mux.ServeHTTP(w, r)
 	}))
 	t.Cleanup(svr.Close)
 

--- a/storage/gcsemu/server.go
+++ b/storage/gcsemu/server.go
@@ -26,9 +26,9 @@ type Server struct {
 func NewServer(laddr string, opts Options) (*Server, error) {
 	gcsEmu := NewGcsEmu(opts)
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", gcsEmu.Handler)
+	gcsEmu.Register(mux)
 
-	srv := httptest.NewUnstartedServer(http.HandlerFunc(gcsEmu.Handler))
+	srv := httptest.NewUnstartedServer(mux)
 	l, err := net.Listen("tcp", laddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on addr %s: %w", laddr, err)


### PR DESCRIPTION
- auto decompresses incoming gzip encoded content
- refactors request body draining out to a wrapper function
- cleans up some wonky HTTP handler registration (the muxes were unused)
- centralizes a single `Register(mux)` method
