### PR TITLE
update memstore impl to return not found when file does not exist on deletion

### DIFF
--- a/storage/gcsemu/memstore.go
+++ b/storage/gcsemu/memstore.go
@@ -155,7 +155,10 @@ func (ms *memstore) Delete(bucket string, filename string) error {
 		// Remove just the file
 		b.mu.Lock()
 		defer b.mu.Unlock()
-		b.files.Delete(ms.key(filename))
+		if b.files.Delete(ms.key(filename)) == nil {
+			// case file does not exist
+			return os.ErrNotExist
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When deleting a file that doesnt exist, emulator had a different behaviour than real GCS. The real one returned a 404 response code for that specific file (not the whole request).

I updated the memstore implementation to return not found when the file doesn't exist and it solved the issue

https://github.com/fullstorydev/emulators/issues/20