### PR TITLE
Transactional filestore Add method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine As builder
+FROM golang:1.20-alpine As builder
 MAINTAINER Fullstory Engineering
 
 # create non-privileged group and user


### PR DESCRIPTION
First of all, thanks for a great working implementation!

This PR makes filestore Add method transactional. In a nutshell, now `Add` creates temp target and temp metadata files, writes both, renames to target. Rationale: avoid reading partially written files.