### PR TITLE
Resumable upload must continue with `PUT`

### DIFF
--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -165,6 +165,13 @@ func (g *GcsEmu) Handler(w http.ResponseWriter, r *http.Request) {
 			// unsupported method, or maybe should never happen
 			g.gapiError(w, http.StatusBadRequest, fmt.Sprintf("unsupported POST request: %v\n%s", r.URL, maybeNotImplementedErrorMsg))
 		}
+	case "PUT":
+		if r.Form.Get("upload_id") != "" {
+			g.handleGcsNewObjectResume(ctx, baseUrl, w, r, r.Form.Get("upload_id"))
+		} else {
+			// unsupported method, or maybe should never happen
+			g.gapiError(w, http.StatusBadRequest, fmt.Sprintf("unsupported PUT request: %v\n%s", r.URL, maybeNotImplementedErrorMsg))
+		}
 	default:
 		g.gapiError(w, http.StatusMethodNotAllowed, "")
 	}


### PR DESCRIPTION
After initiation, resumable uploads in GCS are continued with `PUT` method. In the current master, this part is in `POST` handler, which makes it incompatible with GCS clients.

See reference incompatible client at [googleapis/google-resumable-media-python](https://github.com/googleapis/google-resumable-media-python/blob/de80717a735d40ccf0ac864c074b7de9e0bff5f0/google/resumable_media/_upload.py#L581)

Also see g doc section  [How tools and APIs use resumable uploads (REST APIs)](https://cloud.google.com/storage/docs/resumable-uploads#behavior):
> The Cloud Storage JSON API uses a POST Object request that includes the query parameter `uploadType=resumable` to initiate the resumable upload. This request returns as [session URI](https://cloud.google.com/storage/docs/resumable-uploads#session-uris) that you then use in one or more PUT Object requests to upload the object data. For a step-by-step guide to building your own logic for resumable uploading, see [Performing resumable uploads](https://cloud.google.com/storage/docs/performing-resumable-uploads).
