### PR TITLE
storage: deletes should return http 204

### DIFF
--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -274,7 +274,7 @@ func (g *GcsEmu) handleGcsDelete(ctx context.Context, w http.ResponseWriter, buc
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWriter, acceptEncoding, bucket, filename string) {

--- a/storage/gcsemu/raw_http_test.go
+++ b/storage/gcsemu/raw_http_test.go
@@ -107,7 +107,7 @@ func testRawHttp(t *testing.T, bh BucketHandle, httpClient *http.Client, url str
 				return req
 			},
 			checkResponse: func(t *testing.T, rsp *http.Response) {
-				assert.Equal(t, http.StatusOK, rsp.StatusCode)
+				assert.Equal(t, http.StatusNoContent, rsp.StatusCode)
 			},
 		},
 		{


### PR DESCRIPTION
GCS behavior must have changed at some point, the "real" raw HTTP test against real GCS was failing.  This fixes the code and expectations.