### PR TITLE
Client seems to expect 200 for resumable uploads.

### DIFF
--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -530,7 +530,7 @@ func (g *GcsEmu) handleGcsNewObject(ctx context.Context, baseUrl HttpBaseUrl, w 
 
 		w.Header().Set("Location", ObjectUrl(baseUrl, bucket, obj.Name)+"?upload_id="+id)
 		w.Header().Set("Content-Type", obj.ContentType)
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusOK)
 		return
 	case "multipart":
 		obj, contents, err := readMultipartInsert(r)


### PR DESCRIPTION
I got exceptions from the Java client when running the emulator, and looking at the Java client source code it expects a 200 response instead of 201 when creating with resumable uploads.

See https://github.com/googleapis/java-storage/blob/35b9123745f004c90a3b799ba921ebd77553476a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java#L1099