### PR TITLE
gcsemu: trim os specific path separator

### DIFF
--- a/storage/gcsemu/filestore.go
+++ b/storage/gcsemu/filestore.go
@@ -244,7 +244,7 @@ func (fs *filestore) Walk(ctx context.Context, bucket string, cb func(ctx contex
 		}
 
 		filename := strings.TrimPrefix(path, root)
-		filename = strings.TrimPrefix(filename, "/")
+		filename = strings.TrimPrefix(filename, string(os.PathSeparator))
 		if err != nil {
 			if os.IsNotExist(err) {
 				return err


### PR DESCRIPTION
On windows all files will be prefixed with `\\`, this fixes that by using the os specific path separator