### PR TITLE
fix flakey test

### DIFF
--- a/storage/gcsemu/gcsemu_test.go
+++ b/storage/gcsemu/gcsemu_test.go
@@ -178,7 +178,7 @@ func testHugeFile(t *testing.T, bh BucketHandle) {
 }
 
 func testHugeFileMultipleOfChunkSize(t *testing.T, bh BucketHandle) {
-	doHugeFile(t, bh, "gscemu-test/huge2.txt", googleapi.DefaultUploadChunkSize*4)
+	doHugeFile(t, bh, "gscemu-test/huge_multiple.txt", googleapi.DefaultUploadChunkSize*4)
 }
 
 func doHugeFile(t *testing.T, bh BucketHandle, name string, size int) {


### PR DESCRIPTION
Two tests write to the same filename, causing flakiness when running in parallel. Fix by renaming one of them.