### PR TITLE
gcsemu -- add support for range reads

### DIFF
--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -324,17 +324,18 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
 	w.Header().Set("X-Goog-Metageneration", strconv.FormatInt(obj.Metageneration, 10))
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Expose-Headers", "Content-Type, Content-Length, Content-Encoding, Content-Range, Date, X-Goog-Generation, X-Goog-Metageneration")
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Type, Content-Length, Content-Encoding, Content-Range, Date, X-Goog-Generation, X-Goog-Metageneration, X-Goog-Stored-Content-Encoding")
 	w.Header().Set("Content-Disposition", obj.ContentDisposition)
 
 	if obj.ContentEncoding == "gzip" {
-		if strings.Contains(acceptEncoding, "gzip") && rangeHeader == "" {
-			// Client accepts gzip and no range request: serve compressed content directly.
+		w.Header().Set("X-Goog-Stored-Content-Encoding", "gzip")
+		if strings.Contains(acceptEncoding, "gzip") {
+			// No transcoding: serve compressed bytes directly. Range reads
+			// operate on the compressed bytes normally.
 			w.Header().Set("Content-Encoding", "gzip")
 		} else {
-			// Decompress on behalf of the client. GCS also does this when a
-			// Range header is present on a gzip object -- the range is silently
-			// ignored and the full decompressed content is returned.
+			// Transcoding: decompress on behalf of the client. Range headers
+			// are silently ignored when transcoding occurs.
 			buf := bytes.NewBuffer(contents)
 			gzipReader, err := gzip.NewReader(buf)
 			if err != nil {
@@ -349,7 +350,9 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 			}
 			return
 		}
-	} else if rangeHeader != "" {
+	}
+
+	if rangeHeader != "" {
 		lo, hi, ok := parseRangeRequestHeader(rangeHeader, int64(len(contents)))
 		if !ok {
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", len(contents)))

--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -347,7 +347,13 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 		}
 	}
 
-	if lo, hi, ok := parseRangeRequestHeader(rangeHeader, int64(len(contents))); ok {
+	if rangeHeader != "" {
+		lo, hi, ok := parseRangeRequestHeader(rangeHeader, int64(len(contents)))
+		if !ok {
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", len(contents)))
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
 		sliced := contents[lo : hi+1]
 		w.Header().Set("Content-Length", strconv.Itoa(len(sliced)))
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", lo, hi, len(contents)))

--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -345,9 +345,9 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 			}
 			return
 		}
-	}
-
-	if rangeHeader != "" {
+		// GCS silently ignores Range headers for gzip-encoded objects,
+		// so skip range handling and serve the full compressed content.
+	} else if rangeHeader != "" {
 		lo, hi, ok := parseRangeRequestHeader(rangeHeader, int64(len(contents)))
 		if !ok {
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", len(contents)))

--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -137,7 +137,7 @@ func (g *GcsEmu) Handler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			alt := r.URL.Query().Get("alt")
 			if alt == "media" || (p.IsPublic && alt == "") {
-				g.handleGcsMediaRequest(baseUrl, w, r.Header.Get("Accept-Encoding"), bucket, object)
+				g.handleGcsMediaRequest(baseUrl, w, r.Header.Get("Accept-Encoding"), r.Header.Get("Range"), bucket, object)
 			} else if alt == "json" || (!p.IsPublic && alt == "") {
 				g.handleGcsMetadataRequest(baseUrl, w, bucket, object)
 			} else {
@@ -309,7 +309,51 @@ func (g *GcsEmu) handleGcsDelete(ctx context.Context, w http.ResponseWriter, buc
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWriter, acceptEncoding, bucket, filename string) {
+// parseRangeRequestHeader parses an HTTP Range request header (e.g. "bytes=0-99")
+// and clamps to the given total size. Returns the inclusive lo/hi byte offsets
+// and true if a valid range was parsed.
+func parseRangeRequestHeader(header string, totalSize int64) (lo, hi int64, ok bool) {
+	if !strings.HasPrefix(header, "bytes=") {
+		return 0, 0, false
+	}
+	spec := strings.TrimPrefix(header, "bytes=")
+	parts := strings.SplitN(spec, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+
+	if parts[0] == "" {
+		suffix, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil || suffix <= 0 {
+			return 0, 0, false
+		}
+		lo = totalSize - suffix
+		if lo < 0 {
+			lo = 0
+		}
+		return lo, totalSize - 1, true
+	}
+
+	lo, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || lo < 0 || lo >= totalSize {
+		return 0, 0, false
+	}
+
+	if parts[1] == "" {
+		return lo, totalSize - 1, true
+	}
+
+	hi, err = strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || hi < lo {
+		return 0, 0, false
+	}
+	if hi >= totalSize {
+		hi = totalSize - 1
+	}
+	return lo, hi, true
+}
+
+func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWriter, acceptEncoding, rangeHeader, bucket, filename string) {
 	obj, contents, err := g.store.Get(baseUrl, bucket, filename)
 	if err != nil {
 		g.gapiError(w, http.StatusInternalServerError, fmt.Sprintf("failed to check existence of %s/%s: %s", bucket, filename, err))
@@ -324,7 +368,7 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
 	w.Header().Set("X-Goog-Metageneration", strconv.FormatInt(obj.Metageneration, 10))
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Expose-Headers", "Content-Type, Content-Length, Content-Encoding, Date, X-Goog-Generation, X-Goog-Metageneration")
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Type, Content-Length, Content-Encoding, Content-Range, Date, X-Goog-Generation, X-Goog-Metageneration")
 	w.Header().Set("Content-Disposition", obj.ContentDisposition)
 
 	if obj.ContentEncoding == "gzip" {
@@ -345,6 +389,17 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 			}
 			return
 		}
+	}
+
+	if lo, hi, ok := parseRangeRequestHeader(rangeHeader, int64(len(contents))); ok {
+		sliced := contents[lo : hi+1]
+		w.Header().Set("Content-Length", strconv.Itoa(len(sliced)))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", lo, hi, len(contents)))
+		w.WriteHeader(http.StatusPartialContent)
+		if _, err := w.Write(sliced); err != nil {
+			g.gapiError(w, http.StatusInternalServerError, fmt.Sprintf("failed to copy from %s/%s: %s", bucket, filename, err))
+		}
+		return
 	}
 
 	// Just write the contents

--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -328,14 +328,18 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 	w.Header().Set("Content-Disposition", obj.ContentDisposition)
 
 	if obj.ContentEncoding == "gzip" {
-		if strings.Contains(acceptEncoding, "gzip") {
+		if strings.Contains(acceptEncoding, "gzip") && rangeHeader == "" {
+			// Client accepts gzip and no range request: serve compressed content directly.
 			w.Header().Set("Content-Encoding", "gzip")
 		} else {
-			// Uncompress on behalf of the client.
+			// Decompress on behalf of the client. GCS also does this when a
+			// Range header is present on a gzip object -- the range is silently
+			// ignored and the full decompressed content is returned.
 			buf := bytes.NewBuffer(contents)
 			gzipReader, err := gzip.NewReader(buf)
 			if err != nil {
 				g.gapiError(w, http.StatusInternalServerError, fmt.Sprintf("failed to gunzip from %s/%s: %s", bucket, filename, err))
+				return
 			}
 			if _, err := io.Copy(w, gzipReader); err != nil {
 				g.gapiError(w, http.StatusInternalServerError, fmt.Sprintf("failed to copy+gunzip from %s/%s: %s", bucket, filename, err))
@@ -345,8 +349,6 @@ func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWrite
 			}
 			return
 		}
-		// GCS silently ignores Range headers for gzip-encoded objects,
-		// so skip range handling and serve the full compressed content.
 	} else if rangeHeader != "" {
 		lo, hi, ok := parseRangeRequestHeader(rangeHeader, int64(len(contents)))
 		if !ok {

--- a/storage/gcsemu/gcsemu.go
+++ b/storage/gcsemu/gcsemu.go
@@ -309,50 +309,6 @@ func (g *GcsEmu) handleGcsDelete(ctx context.Context, w http.ResponseWriter, buc
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// parseRangeRequestHeader parses an HTTP Range request header (e.g. "bytes=0-99")
-// and clamps to the given total size. Returns the inclusive lo/hi byte offsets
-// and true if a valid range was parsed.
-func parseRangeRequestHeader(header string, totalSize int64) (lo, hi int64, ok bool) {
-	if !strings.HasPrefix(header, "bytes=") {
-		return 0, 0, false
-	}
-	spec := strings.TrimPrefix(header, "bytes=")
-	parts := strings.SplitN(spec, "-", 2)
-	if len(parts) != 2 {
-		return 0, 0, false
-	}
-
-	if parts[0] == "" {
-		suffix, err := strconv.ParseInt(parts[1], 10, 64)
-		if err != nil || suffix <= 0 {
-			return 0, 0, false
-		}
-		lo = totalSize - suffix
-		if lo < 0 {
-			lo = 0
-		}
-		return lo, totalSize - 1, true
-	}
-
-	lo, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil || lo < 0 || lo >= totalSize {
-		return 0, 0, false
-	}
-
-	if parts[1] == "" {
-		return lo, totalSize - 1, true
-	}
-
-	hi, err = strconv.ParseInt(parts[1], 10, 64)
-	if err != nil || hi < lo {
-		return 0, 0, false
-	}
-	if hi >= totalSize {
-		hi = totalSize - 1
-	}
-	return lo, hi, true
-}
-
 func (g *GcsEmu) handleGcsMediaRequest(baseUrl HttpBaseUrl, w http.ResponseWriter, acceptEncoding, rangeHeader, bucket, filename string) {
 	obj, contents, err := g.store.Get(baseUrl, bucket, filename)
 	if err != nil {

--- a/storage/gcsemu/gcsemu_test.go
+++ b/storage/gcsemu/gcsemu_test.go
@@ -1,6 +1,8 @@
 package gcsemu
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/md5"
 	"errors"
@@ -38,6 +40,7 @@ var (
 		{"CopyMetadata", testCopyMetadata},
 		{"CopyConditionals", testCopyConditionals},
 		{"RangeRead", testRangeRead},
+		{"RangeReadCompressed", testRangeReadCompressed},
 	}
 )
 
@@ -598,17 +601,6 @@ func testListBuckets(t *testing.T, gcsClient *storage.Client, expect []string) {
 	assert.DeepEqual(t, expect, results)
 }
 
-func write(w *storage.Writer, content string) error {
-	n, err := io.Copy(w, strings.NewReader(content))
-	if err != nil {
-		return err
-	}
-	if n != int64(len(content)) {
-		panic("not all content sent")
-	}
-	return w.Close()
-}
-
 func testRangeRead(t *testing.T, bh BucketHandle) {
 	const name = "gcsemu-test/range.bin"
 	const content = "AAABBBCCC"
@@ -657,4 +649,65 @@ func testRangeRead(t *testing.T, bh BucketHandle) {
 	assert.NilError(t, err)
 	assert.NilError(t, r.Close())
 	assert.Equal(t, "BBBCCC", string(data))
+}
+
+func testRangeReadCompressed(t *testing.T, bh BucketHandle) {
+	const name = "gcsemu-test/range-compressed.bin"
+	const plaintext = "AAABBBCCCDDDEEEFFFGGGHHHIIIJJJKKKLLLMMMNNNOOOPPP"
+	ctx := context.Background()
+	oh := bh.Object(name)
+
+	// Compress the content and upload with ContentEncoding: gzip.
+	var compressed bytes.Buffer
+	gw := gzip.NewWriter(&compressed)
+	_, err := gw.Write([]byte(plaintext))
+	assert.NilError(t, err)
+	assert.NilError(t, gw.Close())
+
+	w := oh.NewWriter(ctx)
+	w.ContentEncoding = "gzip"
+	w.ContentType = "application/octet-stream"
+	_, err = io.Copy(w, bytes.NewReader(compressed.Bytes()))
+	assert.NilError(t, err)
+	assert.NilError(t, w.Close())
+
+	// Full read returns decompressed content transparently.
+	r, err := oh.NewReader(ctx)
+	assert.NilError(t, err)
+	data, err := io.ReadAll(r)
+	assert.NilError(t, err)
+	assert.NilError(t, r.Close())
+	assert.Equal(t, plaintext, string(data))
+
+	// GCS silently ignores Range headers for gzip-encoded objects and always
+	// returns the full decompressed content. Verified against real GCS.
+	for _, tc := range []struct {
+		name   string
+		offset int64
+		length int64
+	}{
+		{"from start", 0, 3},
+		{"from middle", 3, 3},
+		{"open-ended", 3, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := oh.NewRangeReader(ctx, tc.offset, tc.length)
+			assert.NilError(t, err)
+			data, err := io.ReadAll(r)
+			assert.NilError(t, err)
+			assert.NilError(t, r.Close())
+			assert.Equal(t, plaintext, string(data))
+		})
+	}
+}
+
+func write(w *storage.Writer, content string) error {
+	n, err := io.Copy(w, strings.NewReader(content))
+	if err != nil {
+		return err
+	}
+	if n != int64(len(content)) {
+		panic("not all content sent")
+	}
+	return w.Close()
 }

--- a/storage/gcsemu/gcsemu_test.go
+++ b/storage/gcsemu/gcsemu_test.go
@@ -40,7 +40,6 @@ var (
 		{"CopyMetadata", testCopyMetadata},
 		{"CopyConditionals", testCopyConditionals},
 		{"RangeRead", testRangeRead},
-		{"RangeReadCompressed", testRangeReadCompressed},
 	}
 )
 
@@ -602,101 +601,180 @@ func testListBuckets(t *testing.T, gcsClient *storage.Client, expect []string) {
 }
 
 func testRangeRead(t *testing.T, bh BucketHandle) {
-	const name = "gcsemu-test/range.bin"
-	const content = "AAABBBCCC"
 	ctx := context.Background()
-	oh := bh.Object(name)
 
-	err := write(oh.NewWriter(ctx), content)
-	assert.NilError(t, err, "write failed")
+	// --- Setup: plain object ---
+	const plainName = "gcsemu-test/range-plain.bin"
+	const plainContent = "AAABBBCCC"
+	err := write(bh.Object(plainName).NewWriter(ctx), plainContent)
+	assert.NilError(t, err, "write plain object failed")
 
-	// Full read still works.
-	r, err := oh.NewReader(ctx)
-	assert.NilError(t, err)
-	data, err := io.ReadAll(r)
-	assert.NilError(t, err)
-	assert.NilError(t, r.Close())
-	assert.Equal(t, content, string(data))
-
-	// Range read: middle slice.
-	r, err = oh.NewRangeReader(ctx, 3, 3)
-	assert.NilError(t, err)
-	data, err = io.ReadAll(r)
-	assert.NilError(t, err)
-	assert.NilError(t, r.Close())
-	assert.Equal(t, "BBB", string(data))
-
-	// Range read: first slice.
-	r, err = oh.NewRangeReader(ctx, 0, 3)
-	assert.NilError(t, err)
-	data, err = io.ReadAll(r)
-	assert.NilError(t, err)
-	assert.NilError(t, r.Close())
-	assert.Equal(t, "AAA", string(data))
-
-	// Range read: last slice.
-	r, err = oh.NewRangeReader(ctx, 6, 3)
-	assert.NilError(t, err)
-	data, err = io.ReadAll(r)
-	assert.NilError(t, err)
-	assert.NilError(t, r.Close())
-	assert.Equal(t, "CCC", string(data))
-
-	// Range read: open-ended (length -1) reads to end.
-	r, err = oh.NewRangeReader(ctx, 3, -1)
-	assert.NilError(t, err)
-	data, err = io.ReadAll(r)
-	assert.NilError(t, err)
-	assert.NilError(t, r.Close())
-	assert.Equal(t, "BBBCCC", string(data))
-}
-
-func testRangeReadCompressed(t *testing.T, bh BucketHandle) {
-	const name = "gcsemu-test/range-compressed.bin"
-	const plaintext = "AAABBBCCCDDDEEEFFFGGGHHHIIIJJJKKKLLLMMMNNNOOOPPP"
-	ctx := context.Background()
-	oh := bh.Object(name)
-
-	// Compress the content and upload with ContentEncoding: gzip.
+	// --- Setup: gzip object ---
+	const gzipName = "gcsemu-test/range-gzip.bin"
+	const gzipPlaintext = "AAABBBCCCDDDEEEFFFGGGHHHIIIJJJKKKLLLMMMNNNOOOPPP"
 	var compressed bytes.Buffer
 	gw := gzip.NewWriter(&compressed)
-	_, err := gw.Write([]byte(plaintext))
+	_, err = gw.Write([]byte(gzipPlaintext))
 	assert.NilError(t, err)
 	assert.NilError(t, gw.Close())
+	compressedBytes := compressed.Bytes()
 
-	w := oh.NewWriter(ctx)
+	w := bh.Object(gzipName).NewWriter(ctx)
 	w.ContentEncoding = "gzip"
 	w.ContentType = "application/octet-stream"
-	_, err = io.Copy(w, bytes.NewReader(compressed.Bytes()))
+	_, err = io.Copy(w, bytes.NewReader(compressedBytes))
 	assert.NilError(t, err)
 	assert.NilError(t, w.Close())
 
-	// Full read returns decompressed content transparently.
-	r, err := oh.NewReader(ctx)
-	assert.NilError(t, err)
-	data, err := io.ReadAll(r)
-	assert.NilError(t, err)
-	assert.NilError(t, r.Close())
-	assert.Equal(t, plaintext, string(data))
+	//
+	// CE=none, AE=none (default, no ReadCompressed): range reads work normally.
+	//
 
-	// GCS silently ignores Range headers for gzip-encoded objects and always
-	// returns the full decompressed content. Verified against real GCS.
+	t.Run("plain/full_read", func(t *testing.T) {
+		r, err := bh.Object(plainName).NewReader(ctx)
+		assert.NilError(t, err)
+		data, err := io.ReadAll(r)
+		assert.NilError(t, err)
+		assert.NilError(t, r.Close())
+		assert.Equal(t, plainContent, string(data))
+	})
+
+	for _, tc := range []struct {
+		name   string
+		offset int64
+		length int64
+		expect string
+	}{
+		{"first", 0, 3, "AAA"},
+		{"middle", 3, 3, "BBB"},
+		{"last", 6, 3, "CCC"},
+		{"open_ended", 3, -1, "BBBCCC"},
+	} {
+		t.Run("plain/range_"+tc.name, func(t *testing.T) {
+			r, err := bh.Object(plainName).NewRangeReader(ctx, tc.offset, tc.length)
+			assert.NilError(t, err)
+			data, err := io.ReadAll(r)
+			assert.NilError(t, err)
+			assert.NilError(t, r.Close())
+			assert.Equal(t, tc.expect, string(data))
+		})
+	}
+
+	t.Run("plain/range_invalid", func(t *testing.T) {
+		_, err := bh.Object(plainName).NewRangeReader(ctx, 100, 3)
+		assert.Check(t, err != nil, "expected error for invalid range")
+		var gerr *googleapi.Error
+		assert.Check(t, errors.As(err, &gerr))
+		assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, gerr.Code)
+	})
+
+	//
+	// CE=none, AE=gzip (ReadCompressed): should be identical to above since
+	// there's nothing to transcode on a non-gzip object.
+	//
+
+	t.Run("plain_compressed/full_read", func(t *testing.T) {
+		r, err := bh.Object(plainName).ReadCompressed(true).NewReader(ctx)
+		assert.NilError(t, err)
+		data, err := io.ReadAll(r)
+		assert.NilError(t, err)
+		assert.NilError(t, r.Close())
+		assert.Equal(t, plainContent, string(data))
+	})
+
+	for _, tc := range []struct {
+		name   string
+		offset int64
+		length int64
+		expect string
+	}{
+		{"first", 0, 3, "AAA"},
+		{"middle", 3, 3, "BBB"},
+		{"open_ended", 3, -1, "BBBCCC"},
+	} {
+		t.Run("plain_compressed/range_"+tc.name, func(t *testing.T) {
+			r, err := bh.Object(plainName).ReadCompressed(true).NewRangeReader(ctx, tc.offset, tc.length)
+			assert.NilError(t, err)
+			data, err := io.ReadAll(r)
+			assert.NilError(t, err)
+			assert.NilError(t, r.Close())
+			assert.Equal(t, tc.expect, string(data))
+		})
+	}
+
+	//
+	// CE=gzip, AE=none (default, no ReadCompressed): server transcodes
+	// (decompresses). GCS silently ignores Range headers when transcoding
+	// and returns the full decompressed content. Verified against real GCS.
+	//
+
+	t.Run("gzip/full_read", func(t *testing.T) {
+		r, err := bh.Object(gzipName).NewReader(ctx)
+		assert.NilError(t, err)
+		data, err := io.ReadAll(r)
+		assert.NilError(t, err)
+		assert.NilError(t, r.Close())
+		assert.Equal(t, gzipPlaintext, string(data))
+	})
+
 	for _, tc := range []struct {
 		name   string
 		offset int64
 		length int64
 	}{
-		{"from start", 0, 3},
-		{"from middle", 3, 3},
-		{"open-ended", 3, -1},
+		{"from_start", 0, 3},
+		{"from_middle", 3, 3},
+		{"open_ended", 3, -1},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			r, err := oh.NewRangeReader(ctx, tc.offset, tc.length)
+		t.Run("gzip/range_"+tc.name, func(t *testing.T) {
+			r, err := bh.Object(gzipName).NewRangeReader(ctx, tc.offset, tc.length)
 			assert.NilError(t, err)
 			data, err := io.ReadAll(r)
 			assert.NilError(t, err)
 			assert.NilError(t, r.Close())
-			assert.Equal(t, plaintext, string(data))
+			assert.Equal(t, gzipPlaintext, string(data))
+		})
+	}
+
+	//
+	// CE=gzip, AE=gzip (ReadCompressed): no server transcoding, client
+	// receives raw compressed bytes. Range behavior in this mode is unclear
+	// -- log results to verify against real GCS.
+	//
+
+	t.Run("gzip_compressed/full_read", func(t *testing.T) {
+		r, err := bh.Object(gzipName).ReadCompressed(true).NewReader(ctx)
+		assert.NilError(t, err)
+		data, err := io.ReadAll(r)
+		assert.NilError(t, err)
+		assert.NilError(t, r.Close())
+		t.Logf("got %d bytes (compressed=%d, plaintext=%d)", len(data), len(compressedBytes), len(gzipPlaintext))
+		assert.DeepEqual(t, compressedBytes, data)
+	})
+
+	for _, tc := range []struct {
+		name   string
+		offset int64
+		length int64
+	}{
+		{"from_start", 0, 3},
+		{"from_middle", 3, 3},
+		{"open_ended", 3, -1},
+	} {
+		t.Run("gzip_compressed/range_"+tc.name, func(t *testing.T) {
+			r, err := bh.Object(gzipName).ReadCompressed(true).NewRangeReader(ctx, tc.offset, tc.length)
+			assert.NilError(t, err)
+			data, err := io.ReadAll(r)
+			assert.NilError(t, err)
+			assert.NilError(t, r.Close())
+
+			var expect []byte
+			if tc.length == -1 {
+				expect = compressedBytes[tc.offset:]
+			} else {
+				expect = compressedBytes[tc.offset : tc.offset+tc.length]
+			}
+			assert.DeepEqual(t, expect, data)
 		})
 	}
 }

--- a/storage/gcsemu/gcsemu_test.go
+++ b/storage/gcsemu/gcsemu_test.go
@@ -37,6 +37,7 @@ var (
 		{"Compose", testCompose},
 		{"CopyMetadata", testCopyMetadata},
 		{"CopyConditionals", testCopyConditionals},
+		{"RangeRead", testRangeRead},
 	}
 )
 
@@ -606,4 +607,54 @@ func write(w *storage.Writer, content string) error {
 		panic("not all content sent")
 	}
 	return w.Close()
+}
+
+func testRangeRead(t *testing.T, bh BucketHandle) {
+	const name = "gcsemu-test/range.bin"
+	const content = "AAABBBCCC"
+	ctx := context.Background()
+	oh := bh.Object(name)
+
+	err := write(oh.NewWriter(ctx), content)
+	assert.NilError(t, err, "write failed")
+
+	// Full read still works.
+	r, err := oh.NewReader(ctx)
+	assert.NilError(t, err)
+	data, err := io.ReadAll(r)
+	assert.NilError(t, err)
+	assert.NilError(t, r.Close())
+	assert.Equal(t, content, string(data))
+
+	// Range read: middle slice.
+	r, err = oh.NewRangeReader(ctx, 3, 3)
+	assert.NilError(t, err)
+	data, err = io.ReadAll(r)
+	assert.NilError(t, err)
+	assert.NilError(t, r.Close())
+	assert.Equal(t, "BBB", string(data))
+
+	// Range read: first slice.
+	r, err = oh.NewRangeReader(ctx, 0, 3)
+	assert.NilError(t, err)
+	data, err = io.ReadAll(r)
+	assert.NilError(t, err)
+	assert.NilError(t, r.Close())
+	assert.Equal(t, "AAA", string(data))
+
+	// Range read: last slice.
+	r, err = oh.NewRangeReader(ctx, 6, 3)
+	assert.NilError(t, err)
+	data, err = io.ReadAll(r)
+	assert.NilError(t, err)
+	assert.NilError(t, r.Close())
+	assert.Equal(t, "CCC", string(data))
+
+	// Range read: open-ended (length -1) reads to end.
+	r, err = oh.NewRangeReader(ctx, 3, -1)
+	assert.NilError(t, err)
+	data, err = io.ReadAll(r)
+	assert.NilError(t, err)
+	assert.NilError(t, r.Close())
+	assert.Equal(t, "BBBCCC", string(data))
 }

--- a/storage/gcsemu/range.go
+++ b/storage/gcsemu/range.go
@@ -13,6 +13,9 @@ type byteRange struct {
 // and clamps to the given total size. Returns the inclusive lo/hi byte offsets
 // and true if a valid range was parsed.
 func parseRangeRequestHeader(header string, totalSize int64) (lo, hi int64, ok bool) {
+	if totalSize <= 0 {
+		return 0, 0, false
+	}
 	if !strings.HasPrefix(header, "bytes=") {
 		return 0, 0, false
 	}

--- a/storage/gcsemu/range.go
+++ b/storage/gcsemu/range.go
@@ -9,6 +9,50 @@ type byteRange struct {
 	lo, hi, sz int64
 }
 
+// parseRangeRequestHeader parses an HTTP Range request header (e.g. "bytes=0-99")
+// and clamps to the given total size. Returns the inclusive lo/hi byte offsets
+// and true if a valid range was parsed.
+func parseRangeRequestHeader(header string, totalSize int64) (lo, hi int64, ok bool) {
+	if !strings.HasPrefix(header, "bytes=") {
+		return 0, 0, false
+	}
+	spec := strings.TrimPrefix(header, "bytes=")
+	parts := strings.SplitN(spec, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+
+	if parts[0] == "" {
+		suffix, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil || suffix <= 0 {
+			return 0, 0, false
+		}
+		lo = totalSize - suffix
+		if lo < 0 {
+			lo = 0
+		}
+		return lo, totalSize - 1, true
+	}
+
+	lo, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || lo < 0 || lo >= totalSize {
+		return 0, 0, false
+	}
+
+	if parts[1] == "" {
+		return lo, totalSize - 1, true
+	}
+
+	hi, err = strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || hi < lo {
+		return 0, 0, false
+	}
+	if hi >= totalSize {
+		hi = totalSize - 1
+	}
+	return lo, hi, true
+}
+
 func parseByteRange(in string) *byteRange {
 	var err error
 	if !strings.HasPrefix(in, "bytes ") {

--- a/storage/gcsemu/range_test.go
+++ b/storage/gcsemu/range_test.go
@@ -37,6 +37,8 @@ func TestParseRangeRequestHeader(t *testing.T) {
 		{header: "bytes=0-0", totalSize: 500, lo: 0, hi: 0, ok: true},
 		{header: "not-a-range", totalSize: 500, lo: 0, hi: 0, ok: false},
 		{header: "bytes=500-600", totalSize: 500, lo: 0, hi: 0, ok: false},
+		{header: "bytes=0-99", totalSize: 0, lo: 0, hi: 0, ok: false},
+		{header: "bytes=-100", totalSize: 0, lo: 0, hi: 0, ok: false},
 	}
 
 	for _, tc := range tcs {

--- a/storage/gcsemu/range_test.go
+++ b/storage/gcsemu/range_test.go
@@ -21,3 +21,29 @@ func TestParseByteRange(t *testing.T) {
 		assert.Equal(t, tc.expect, *parseByteRange(tc.in))
 	}
 }
+
+func TestParseRangeRequestHeader(t *testing.T) {
+	tcs := []struct {
+		header    string
+		totalSize int64
+		lo, hi    int64
+		ok        bool
+	}{
+		{header: "bytes=0-99", totalSize: 500, lo: 0, hi: 99, ok: true},
+		{header: "bytes=0-99", totalSize: 50, lo: 0, hi: 49, ok: true},
+		{header: "bytes=10-", totalSize: 500, lo: 10, hi: 499, ok: true},
+		{header: "bytes=-100", totalSize: 500, lo: 400, hi: 499, ok: true},
+		{header: "bytes=-600", totalSize: 500, lo: 0, hi: 499, ok: true},
+		{header: "bytes=0-0", totalSize: 500, lo: 0, hi: 0, ok: true},
+		{header: "not-a-range", totalSize: 500, lo: 0, hi: 0, ok: false},
+		{header: "bytes=500-600", totalSize: 500, lo: 0, hi: 0, ok: false},
+	}
+
+	for _, tc := range tcs {
+		t.Logf("test case: %s (totalSize=%d)", tc.header, tc.totalSize)
+		lo, hi, ok := parseRangeRequestHeader(tc.header, tc.totalSize)
+		assert.Equal(t, tc.ok, ok)
+		assert.Equal(t, tc.lo, lo)
+		assert.Equal(t, tc.hi, hi)
+	}
+}

--- a/storage/gcsemu/raw_http_test.go
+++ b/storage/gcsemu/raw_http_test.go
@@ -3,11 +3,10 @@ package gcsemu
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
-	api "google.golang.org/api/storage/v1"
-	"gotest.tools/v3/assert"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -16,6 +15,9 @@ import (
 	"net/textproto"
 	"strings"
 	"testing"
+
+	api "google.golang.org/api/storage/v1"
+	"gotest.tools/v3/assert"
 )
 
 func testRawHttp(t *testing.T, bh BucketHandle, httpClient *http.Client, url string) {
@@ -222,6 +224,77 @@ func testRawHttp(t *testing.T, bh BucketHandle, httpClient *http.Client, url str
 			assert.NilError(t, err)
 			t.Log(string(body))
 			tc.checkResponse(t, rsp)
+		})
+	}
+
+	// Test X-Goog-Stored-Content-Encoding header on gzip objects.
+	const gzipObjName = "gcsemu-raw-gzip.bin"
+	{
+		var compressed bytes.Buffer
+		gw := gzip.NewWriter(&compressed)
+		_, err := gw.Write([]byte("hello world"))
+		assert.NilError(t, err)
+		assert.NilError(t, gw.Close())
+
+		ow := bh.Object(gzipObjName).NewWriter(ctx)
+		ow.ContentEncoding = "gzip"
+		ow.ContentType = "text/plain"
+		_, err = io.Copy(ow, bytes.NewReader(compressed.Bytes()))
+		assert.NilError(t, err)
+		assert.NilError(t, ow.Close())
+	}
+
+	gzipHeaderTests := []struct {
+		name           string
+		acceptEncoding string
+		rangeHeader    string
+		wantStoredCE   string
+	}{
+		{
+			name:           "gzip_transcoding",
+			acceptEncoding: "",
+			wantStoredCE:   "gzip",
+		},
+		{
+			name:           "gzip_no_transcode",
+			acceptEncoding: "gzip",
+			wantStoredCE:   "gzip",
+		},
+		{
+			name:           "gzip_transcoding_with_range",
+			acceptEncoding: "",
+			rangeHeader:    "bytes=0-2",
+			wantStoredCE:   "gzip",
+		},
+		{
+			name:           "gzip_no_transcode_with_range",
+			acceptEncoding: "gzip",
+			rangeHeader:    "bytes=0-2",
+			wantStoredCE:   "gzip",
+		},
+	}
+
+	for _, tc := range gzipHeaderTests {
+		tc := tc
+		t.Run("gzipHeaders/"+tc.name, func(t *testing.T) {
+			u := fmt.Sprintf("%s/download/storage/v1/b/%s/o/%s?alt=media", url, bh.Name, gzipObjName)
+			req, err := http.NewRequest("GET", u, nil)
+			assert.NilError(t, err)
+			if tc.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tc.acceptEncoding)
+			}
+			if tc.rangeHeader != "" {
+				req.Header.Set("Range", tc.rangeHeader)
+			}
+
+			rsp, err := httpClient.Do(req)
+			assert.NilError(t, err)
+			body, err := httputil.DumpResponse(rsp, true)
+			assert.NilError(t, err)
+			t.Log(string(body))
+
+			assert.Equal(t, tc.wantStoredCE, rsp.Header.Get("X-Goog-Stored-Content-Encoding"),
+				"X-Goog-Stored-Content-Encoding mismatch")
 		})
 	}
 


### PR DESCRIPTION
ran into an issue with range reads, the emulator was returning the full contents and ignoring the range headers. added `X-Goog-Stored-Content-Encoding` response header on gzipped objects to match real gcs. permutations of range & gzip headers outlined below:

| **Object Content-Encoding** | **Client Accept-Encoding** | **Client Range** | **Emulator Action** | **HTTP Status** | **Key Response Headers** |
|---|---|---|---|---|---|
| none | none | none | Serve full object exactly as stored. | 200 OK | Standard |
| none | none | n-m | Serve bytes n-m of the stored object. | 206 Partial Content | Standard |
| none | gzip | none | Serve full object exactly as stored. | 200 OK | Standard |
| none | gzip | n-m | Serve bytes n-m of the stored object. | 206 Partial Content | Standard |
| gzip | none | none | Decompress on server. Serve full **decompressed** object. | 200 OK | **Drop** Content-Encoding<br><br>**Drop** Content-Length |
| gzip | none | n-m | **Ignore Range.** Decompress on server. Serve full **decompressed** object. | 200 OK | **Drop** Content-Encoding<br><br>**Drop** Content-Length |
| gzip | gzip | none | Bypass decompression. Serve full **compressed** object. | 200 OK | **Keep** Content-Encoding: gzip |
| gzip | gzip | n-m | Bypass decompression. Serve bytes n-m of the **compressed** object. | 206 Partial Content | **Keep** Content-Encoding: gzip |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the emulator’s object download behavior to honor `Range` headers (including `206`/`416` responses) and alters gzip handling to match GCS, which could affect any tests or clients relying on previous full-body responses.
> 
> **Overview**
> Adds `Range` header support to `GET ?alt=media` responses in `gcsemu`, returning `206 Partial Content` with `Content-Range`/`Content-Length` for valid byte ranges and `416 Requested Range Not Satisfiable` for invalid ranges.
> 
> Updates gzip-encoded object behavior to better match real GCS: serve compressed bytes only when the client accepts gzip *and* no range is requested; otherwise decompress and return the full body. Adds range parsing via `parseRangeRequestHeader` plus new unit/integration tests covering range reads and gzip+range semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6370dfaff87cb55a09f19821df40a2c66d44575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->